### PR TITLE
Linode Script OKed for Debian 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ First, copy the `LinodeStandup.sh` script to your Linode:
 1. Copy the complete [LinodeStandup.sh script](https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts/blob/master/Scripts/LinodeStandUp.sh).
 2. Go to the [Stackscripts page](https://cloud.linode.com/stackscripts?type=account) on your Linode account; choose [Create New Stackscript](https://cloud.linode.com/stackscripts/create)
 3. Paste `LinodeStandup.sh` into the "Script" area. Make sure you got it all, from the "#!/bin/bash" to the "exit 1"!
-4. Choose "Debian 9" (Stretch) for the "Target Images".
+4. Choose "Debian 10" (Buster) for the "Target Images".
 5. Click "Save".
 
 Second, create a node based on the script:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ For more information on *Bitcoin-Standup*:
 
 There are two linux based StandUp scripts; `StandUp.sh` and `LinodeStandUp.sh`.
 
-* `LinodeStandUp.sh` is built as a StackScript for the Linode platform and can be used as is.
-* `StandUp.sh` can be used on a Debian VPS and has been tested on Debian Stretch and Ubuntu 18.04.
+* `LinodeStandUp.sh` is built as a StackScript for the Linode platform and can be used as is. It's been tested on Debian 9 (Stretch) and Debian 10 (Buster).
+* `StandUp.sh` can be used on a Debian VPS and has been tested on Debian 9 (Stretch) and Ubuntu 18.04.
 
 You will use different installation methods depending on which script you use (or if you want to run the installation entirely by hand)
 


### PR DESCRIPTION
As far as I can tell, Debian 10 only required one change to the Linode Standup script: adding in gnupg as an apt-get. It must have gone from standard to optional. 

I've stood-up a new node under Debian 10, and gave it overnight to sync, and it all looks clean. So, I'm now suggesting our docs recommend Debian 10 for the default of the Standup stackscript, not 9. (And I'll be continuing to work through my node using Debian 10 in the coming days and weeks, so if anything is wonky I should see it.)

I think it's likely the other script can be pushed over in the same manner, just match my recent PRs for LinodeStandup, which basically requires: (1) apt-getting gnupg and (2) making a few changes to the signature verification section (though the lack of gnupg was the only critical error, the others just wouldn't verify the sig for Bitcoin Core).