### PR TITLE
fix: mirror virtual ports with their respective rpcport to ensure cross app compatibility

### DIFF
--- a/Scripts/LinodeStandUp.sh
+++ b/Scripts/LinodeStandUp.sh
@@ -207,9 +207,9 @@ sed -i -e 's/## address y:z./## address y:z.\
 \
 HiddenServiceDir \/var\/lib\/tor\/standup\/\
 HiddenServiceVersion 3\
-HiddenServicePort 1309 127.0.0.1:18332\
-HiddenServicePort 1309 127.0.0.1:18443\
-HiddenServicePort 1309 127.0.0.1:8332/g' /etc/tor/torrc
+HiddenServicePort 18332 127.0.0.1:18332\
+HiddenServicePort 18443 127.0.0.1:18443\
+HiddenServicePort 8332 127.0.0.1:8332/g' /etc/tor/torrc
 mkdir /var/lib/tor/standup
 chown -R debian-tor:debian-tor /var/lib/tor/standup
 chmod 700 /var/lib/tor/standup
@@ -467,7 +467,7 @@ sudo systemctl start bitcoind.service
 HS_HOSTNAME=$(sudo cat /var/lib/tor/standup/hostname)
 
 # Create the QR string
-QR="btcstandup://StandUp:$RPCPASSWORD@$HS_HOSTNAME:1309/?label=LinodeStandUp.sh"
+QR="btcstandup://StandUp:$RPCPASSWORD@$HS_HOSTNAME:8332/?label=LinodeStandUp.sh"
 echo "$0 - Ready to display the QuickConnect QR, first we need to install qrencode and fim"
 
 # Get software packages for encoding a QR code and displaying it in a terminal


### PR DESCRIPTION
Generally apps will not recognize what port 1309 is for. However if it includes 8332 most wallet apps will recognize it as Bitcoin Core mainnet and behave as such. This improves UX for standup users across existing and future external apps. It is also poor practice to use the same virtual port for multiple hidden services and is not recommended by the tor project.