### PR TITLE
Fix - SIG VERIFICATION ERROR #44

### DIFF
--- a/Scripts/LinodeStandUp.sh
+++ b/Scripts/LinodeStandUp.sh
@@ -271,7 +271,7 @@ sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-l
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/builder-keys/keys.txt -O ~standup/keys.txt
+sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt
 sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
 
 # Verifying Bitcoin: Signature

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -309,7 +309,7 @@ sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-l
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/builder-keys/keys.txt -O ~standup/keys.txt
+sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt
 sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
 
 # Verifying Bitcoin: Signature


### PR DESCRIPTION
For detailed explanation see issue https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts/issues/44

I don't have a Linode account, so I tested `StandUp.sh` only on a GCP virtual machine

After running the script I tested signatures as described [here](https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/02_1_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md#verify-the-bitcoin-setup) by:

    $ sudo grep VERIFICATION /standup.log

and the following ouput was obtained:

    ./standup.sh - SIG VERIFICATION SUCCESS: 9 GOOD SIGNATURES FOUND.
    ./standup.sh - SHA VERIFICATION SUCCESS / SHA: bitcoin-23.0-x86_64-linux-gnu.tar.gz: OK

which is what is expected, ie the change has been successful

Out of curiosity I tested `LinodeStandUp.sh` on another GCP virtual machine and it worked, however proper testing
should be done on a Linode virtual machine as this script is expected to run on Linode.

That said, changing an URL should not introduce any platform dependent issue, so it is expected `LinodeStandUp.sh`  to run smoothly

### TODO

- [ ] test `LinodeStandUp.sh`
- [x] test `StandUp.sh`
- [x] test `LinodeStandUp.sh` by mantainer
- [x] test `StandUp.sh` by mantainer
- [ ] do not forget to squash commits

### DOUBT
I read the [contrib file ](https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts/blob/master/CONTRIBUTING.md )but did not understand whether I should sign commits with a PGP key or not

