### PR TITLE
Update to Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The *Bitcoin-Standup-Scripts* are updated every year or two for the newest versi
 
 There are two linux based StandUp scripts; `StandUp.sh` and `LinodeStandUp.sh`.
 
-* `LinodeStandUp.sh` is built as a StackScript for the Linode platform and can be used as is. It's been tested on Debian 11 (Bullseye), with previous versions tested on Debian 9 (Stretch) and Debian 10 (Buster).
-* `StandUp.sh` can be used on a Debian VPS and has been tested on Debian 11 (Bullseye), with previous versions tested on Debian 9 (Stretch) and Ubuntu 18.04.
+* `LinodeStandUp.sh` is built as a StackScript for the Linode platform and can be used as is. It's been tested on Debian 12 (Bookworm), with previous versions tested on Debian 9 (Stretch), Debian 10 (Buster) and Debian 11 (Bullseye).
+* `StandUp.sh` can be used on a Debian VPS and has been tested on Debian 12 (Bookworm), with previous versions tested on Debian 9 (Stretch), Debian 11 (Bullseye) and Ubuntu 18.04.
 
 You will use different installation methods depending on which script you use (or if you want to run the installation entirely by hand)
 
@@ -70,7 +70,7 @@ First, copy the `LinodeStandup.sh` script to your Linode:
 1. Copy the complete [LinodeStandup.sh script](https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts/blob/master/Scripts/LinodeStandUp.sh).
 2. Go to the [Stackscripts page](https://cloud.linode.com/stackscripts?type=account) on your Linode account; choose [Create New Stackscript](https://cloud.linode.com/stackscripts/create)
 3. Paste `LinodeStandup.sh` into the "Script" area. Make sure you got it all, from the "#!/bin/bash" to the "exit 1"!
-4. Choose "Debian 11" (Bullseye) for the "Target Images".
+4. Choose "Debian 12" (Bookworm) for the "Target Images".
 5. Click "Save".
 
 Second, create a node based on the script:

--- a/Scripts/LinodeStandUp.sh
+++ b/Scripts/LinodeStandUp.sh
@@ -267,12 +267,18 @@ echo "$0 - Downloading Bitcoin; this will also take a while!"
 
 export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -O ~standup/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS
+sudo -u standup mkdir ~standup/.logs
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -O ~standup/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -a ~standup/.logs/wget
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc -a ~standup/.logs/wget
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -a ~standup/.logs/wget
+
+sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -a ~standup/.logs/wget
 sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
+
+cat ~standup/.logs/wget >> /standup.log
+cat ~standup/.logs/wget >> /standup.err
+rm -r ~standup/.logs
 
 # Verifying Bitcoin: Signature
 echo "$0 - Verifying Bitcoin."

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -302,7 +302,7 @@ echo "$0 - Downloading Bitcoin; this will also take a while!"
 
 # CURRENT BITCOIN RELEASE:
 # Change as necessary
-export BITCOIN="bitcoin-core-25.0"
+export BITCOIN="bitcoin-core-2530"
 export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 
 sudo -u standup mkdir ~standup/logs
@@ -311,7 +311,7 @@ sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-l
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc -o ~standup/logs/wget.log
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -o ~standup/logs/wget.log
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/25.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -o ~standup/logs/wget.log
+sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -o ~standup/logs/wget.log
 sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
 
 # Verifying Bitcoin: Signature

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -302,14 +302,16 @@ echo "$0 - Downloading Bitcoin; this will also take a while!"
 
 # CURRENT BITCOIN RELEASE:
 # Change as necessary
-export BITCOIN="bitcoin-core-23.0"
+export BITCOIN="bitcoin-core-25.0"
 export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -O ~standup/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS
+sudo -u standup mkdir ~standup/logs
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -O ~standup/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -o ~standup/logs/wget.log
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc -o ~standup/logs/wget.log
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -o ~standup/logs/wget.log
+
+sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/25.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -o ~standup/logs/wget.log
 sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
 
 # Verifying Bitcoin: Signature

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -302,7 +302,7 @@ echo "$0 - Downloading Bitcoin; this will also take a while!"
 
 # CURRENT BITCOIN RELEASE:
 # Change as necessary
-export BITCOIN="bitcoin-core-2530"
+export BITCOIN="bitcoin-core-23.0"
 export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 
 sudo -u standup mkdir ~standup/logs

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -305,14 +305,18 @@ echo "$0 - Downloading Bitcoin; this will also take a while!"
 export BITCOIN="bitcoin-core-23.0"
 export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 
-sudo -u standup mkdir ~standup/logs
+sudo -u standup mkdir ~standup/.logs
 
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -O ~standup/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -o ~standup/logs/wget.log
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc -o ~standup/logs/wget.log
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -o ~standup/logs/wget.log
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -O ~standup/$BITCOINPLAIN-x86_64-linux-gnu.tar.gz -a ~standup/.logs/wget
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc -a ~standup/.logs/wget
+sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -a ~standup/.logs/wget
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -o ~standup/logs/wget.log
+sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -a ~standup/.logs/wget
 sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
+
+cat ~standup/.logs/wget >> /standup.log
+cat ~standup/.logs/wget >> /standup.err
+rm -r ~standup/.logs
 
 # Verifying Bitcoin: Signature
 echo "$0 - Verifying Bitcoin."


### PR DESCRIPTION
**Goal**: make both standup scripts work with Debian 12

**Why this patch ?** 

- bcs `wget` started writing logs file as explained more in details [here](https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts/issues/46)
- to update readme file and let users know they can run both scripts with debian 12

**Other comments** 

- The workaround described [here](https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts/issues/46) works however the append option `-a` is preferred to option `-o`, this way we have a single log file for `wget` and then it is easier to append logs to `standup.log` and `standup.err` log files

- `wget` command is used other 2 times in the scripts, but without `sudo -u standup`, ie no issues with logs here and no need to add option `-a`

- changes are retrocompatible and work also on Debian 11 but `StandUp.sh` script has been tested only

### TODO

- [ ] test `LinodeStandUp.sh`
- [x] test `StandUp.sh`
- [x] test `LinodeStandUp.sh` by maintainer
- [x] test `StandUp.sh` by maintainer
- [ ] do not forget to squash commits

### NEXT STEPS

- [ ] if pull is approved and merged then patch also [here](https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/02_1_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md) to let users know they can run on debian 12


