### PR TITLE
Update to Bitcoin core 25.0

### DIFF
--- a/Scripts/LinodeStandUp.sh
+++ b/Scripts/LinodeStandUp.sh
@@ -82,7 +82,7 @@ fi
 
 # CURRENT BITCOIN RELEASE:
 # Change as necessary
-export BITCOIN="bitcoin-core-23.0"
+export BITCOIN="bitcoin-core-25.0"
 
 # Output stdout and stderr to ~root files
 exec > >(tee -a /standup.log) 2> >(tee -a /standup.log /standup.err >&2)
@@ -134,6 +134,9 @@ apt-get install haveged -y
 
 # Install GPG
 apt-get install gnupg -y
+
+# Install git
+apt-get install git
 
 # Set system to automatically update
 echo "unattended-upgrades unattended-upgrades/enable_auto_updates boolean true" | debconf-set-selections
@@ -273,8 +276,8 @@ sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-l
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc -a ~standup/.logs/wget
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -a ~standup/.logs/wget
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -a ~standup/.logs/wget
-sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
+sudo -u standup git clone https://github.com/bitcoin-core/guix.sigs ~standup/guix.sigs
+sudo -u standup gpg --import ~standup/guix.sig
 
 cat ~standup/.logs/wget >> /standup.log
 cat ~standup/.logs/wget >> /standup.err

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -138,6 +138,9 @@ apt-get install gnupg -y
 # Install dirmngr
 apt-get install dirmngr
 
+# Install git
+apt-get install git
+
 # Set system to automatically update
 echo "unattended-upgrades unattended-upgrades/enable_auto_updates boolean true" | debconf-set-selections
 apt-get -y install unattended-upgrades
@@ -311,8 +314,8 @@ sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-x86_64-l
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc -a ~standup/.logs/wget
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -a ~standup/.logs/wget
 
-sudo -u standup wget https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt -O ~standup/keys.txt -a ~standup/.logs/wget
-sudo -u standup  sh -c 'while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~standup/keys.txt'
+sudo -u standup git clone https://github.com/bitcoin-core/guix.sigs ~standup/guix.sigs
+sudo -u standup  gpg --import ~standup/guix.sigs/builder-keys/*
 
 cat ~standup/.logs/wget >> /standup.log
 cat ~standup/.logs/wget >> /standup.err

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -305,7 +305,7 @@ echo "$0 - Downloading Bitcoin; this will also take a while!"
 
 # CURRENT BITCOIN RELEASE:
 # Change as necessary
-export BITCOIN="bitcoin-core-23.0"
+export BITCOIN="bitcoin-core-25.0"
 export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 
 sudo -u standup mkdir ~standup/.logs
@@ -315,7 +315,7 @@ sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~sta
 sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS -O ~standup/SHA256SUMS -a ~standup/.logs/wget
 
 sudo -u standup git clone https://github.com/bitcoin-core/guix.sigs ~standup/guix.sigs
-sudo -u standup  gpg --import ~standup/guix.sigs/builder-keys/*
+sudo -u standup gpg --import ~standup/guix.sigs/builder-keys/*
 
 cat ~standup/.logs/wget >> /standup.log
 cat ~standup/.logs/wget >> /standup.err


### PR DESCRIPTION
**Goal**: update to bitcoin core 25.0

**Overview**
Updating to 25.0 should be only about updating env var [`BITCOIN`](https://github.com/BuildWithData/Bitcoin-Standup-Scripts/blob/master/Scripts/StandUp.sh#L305), but that is not true bcs the URL for [25.0](https://raw.githubusercontent.com/bitcoin/bitcoin/25.x/contrib/builder-keys/keys.txt) public key fingerprints does not exist anymore, whereas it still available for pvs versions like [23.0](https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt) and [24.0](https://raw.githubusercontent.com/bitcoin/bitcoin/23.x/contrib/builder-keys/keys.txt)

From 25.0 keys will always be found in a separate [repo](https://github.com/bitcoin-core/guix.sigs) as explained [here](https://bitcointalk.org/index.php?topic=5433619.msg61568660#msg61568660) by @achow101 

Currently both standup scripts grab the `keys.txt` file from target URL version and then download keys from a key-server as we can see [here](https://github.com/BuildWithData/Bitcoin-Standup-Scripts/blob/master/Scripts/StandUp.sh#L315). However an analogus file like `keys.txt` with all fingerprints is not found in this new repo, but instead all public keys can be found for each release in the corresponding version folder.

On top of that in the [`builder-keys` ](https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys) folder, it seems like we can find all updated public keys, so apperently there is no need to download public keys from a key-server as they can all be found in this folder

**Solution**
In this pull request keys are not downloaded from a key-server anymore, but instead first we download the new repo and second import keys from the `builder-keys` folder

**Doubt/Question**
Couldn't figure out how to use `wget` to download the new repo from github, ie `git` is installed here. Is this a problem ? asking this bcs adding another software on a machine, where we run a node, might introduce some vulnerability. I don't think this is the case as `git` is a well know piece of software, but again no experience on this matter

### TODO

- [ ] test `LinodeStandUp.sh`
- [x] test `StandUp.sh`
- [ ] test `LinodeStandUp.sh` by maintainer
- [ ] test `StandUp.sh` by maintainer
- [ ] do not forget to squash commits

### NEXT STEP
If this pull gets merged, then [this](oin-Core_VPS_with_StackScript.md#verify-your-installation) must be updated as example shows version 22.0  in `bitcoin-22.0-x86_64-linux-gnu.tar.gz` and the `keys.txt` file 






